### PR TITLE
[bugfix] Stop listing representative and id twice in path

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,11 +28,11 @@ Rails.application.routes.draw do
     resources :representatives, only: [:index]
     resources :representatives do
         resources :news_items, only: %i[index show]
-        get '/representatives/:representative_id/my_news_item/new' => 'my_news_items#new',
+        get '/my_news_item/new' => 'my_news_items#new',
             :as                                                    => :new_my_news_item
-        match '/representatives/:representative_id/my_news_item/new', to:  'my_news_items#create',
+        match '/my_news_item/new', to:  'my_news_items#create',
                                                                       via: [:post]
-        match '/representatives/:representative_id/my_news_item/search', to:  'my_news_items#search',
+        match '/my_news_item/search', to:  'my_news_items#search',
                                                                       via: [:get]                                                           
         get '/representatives/:representative_id/my_news_item/:id' => 'my_news_items#edit',
             :as                                                    => :edit_my_news_item


### PR DESCRIPTION
Closes #23 by fixing bug in `routes.rb`